### PR TITLE
654 gpu access for apps

### DIFF
--- a/FeatureCloud/api/cli/controller/commands.py
+++ b/FeatureCloud/api/cli/controller/commands.py
@@ -15,15 +15,16 @@ def controller() -> None:
 @click.argument('name', type=str, default=commands.DEFAULT_CONTROLLER_NAME, nargs=1, required=False)
 @click.option('--port', default=8000, help='Controller port number. Optional parameter (e.g. --port=8000).', required=False)
 @click.option('--data-dir', default='data', help='Controller data directory. Optional parameter (e.g. --data-dir=./data).', required=False)
-def start(name: str, port: int, data_dir: str) -> None:
+@click.option('--gpu', help='Start controller with GPU access. If this succeeds, controller can allow GPU access for apps.', default=False, required=False)
+def start(name: str, port: int, data_dir: str, gpu: bool) -> None:
     """Start a controller instance.
 
     NAME is the controller instance name
 
-    Example: featurecloud controller start my-fc-controller
+    Example: featurecloud controller start my-fc-controller --gpu=True
     """
     try:
-        commands.start(name, port, data_dir)
+        commands.start(name, port, data_dir, gpu)
         click.echo(f'Started controller: {name}')
     except FCException as e:
         if str(e).find("port is already allocated") > -1:

--- a/FeatureCloud/api/imp/controller/commands.py
+++ b/FeatureCloud/api/imp/controller/commands.py
@@ -17,7 +17,7 @@ LOG_FETCH_INTERVAL = 3  # seconds
 LOG_LEVEL_CHOICES = ['debug', 'info', 'warn', 'error', 'fatal']
 
 
-def start(name: str, port: int, data_dir: str):
+def start(name: str, port: int, data_dir: str, with_gpu: bool):
     client = get_docker_client()
 
     data_dir = data_dir if data_dir else DEFAULT_DATA_DIR
@@ -50,6 +50,13 @@ def start(name: str, port: int, data_dir: str):
     # forward slash works on all platforms
     base_dir = getcwd_fslash()
 
+    device_requests = None
+    gpu_command = ""
+    if with_gpu:
+        # '--gpus all' option
+        device_requests = [docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])]
+        gpu_command = '--has-gpu'
+
     try:
         client.containers.run(
             CONTROLLER_IMAGE,
@@ -59,7 +66,8 @@ def start(name: str, port: int, data_dir: str):
             ports={8000: port if port else DEFAULT_PORT},
             volumes=[f'{base_dir}/{data_dir}:/{data_dir}', '/var/run/docker.sock:/var/run/docker.sock'],
             labels=[CONTROLLER_LABEL],
-            command=f"--host-root={base_dir}/{data_dir} --internal-root=/{data_dir} --controller-name={cont_name}"
+            device_requests=device_requests,
+            command=f"--host-root={base_dir}/{data_dir} --internal-root=/{data_dir} --controller-name={cont_name} {gpu_command}"
         )
     except docker.errors.DockerException as e:
         raise FCException(e)

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,3 @@
 python3 -m pip uninstall -y featurecloud
 python3 setup.py sdist
-python3 -m pip install dist/FeatureCloud-0.0.17.tar.gz
+python3 -m pip install dist/FeatureCloud-0.0.19.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(name="FeatureCloud",
-                 version="0.0.18",
+                 version="0.0.19",
                  author="FeatureCloud",
                  author_email="mohammad.bakhtiari@uni-hamburg.de",
                  description="Secure Federated Learning Platform",


### PR DESCRIPTION
pip package specifies the controller's new configuration value `has-gpu`.

How to test:
try commands:

`featurecloud controller start`
`featurecloud controller start --gpu=true`
`featurecloud controller start --gpu=false`

and observe the controller logs. There should be a log entry among the first few log entries:
`time="..." level=info msg="[MAIN]  Configuration value 'HasGPU': true"` or `false`