### PR TITLE
added print-logs option when starting tests, possible todo would be t…

### DIFF
--- a/FeatureCloud/api/cli/test/commands.py
+++ b/FeatureCloud/api/cli/test/commands.py
@@ -46,7 +46,7 @@ def help():
               help='A directory name where to download results. This will be created into /data/tests directory (e.g. featurecloud test start --download-results=./results).',
               default='')
 @click.option('--print-logs',
-              help='When selected, will start a test and then monitor it, printing the current status every 3s. When the test is finnished (or has an error), the relevant logs will be outrput. Canceling the command after the test was started will NOT stop the test.',
+              help='When selected, it will monitor the started test by printing the current status every 3s. When the test is finished (or has an error), the relevant logs will be output. Canceling the command after the test was started will NOT stop the test.',
               is_flag=True)
 def start(controller_host: str, client_dirs: str, generic_dir: str, app_image: str, channel: str, query_interval: str,
           download_results: str, print_logs: bool):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(name="FeatureCloud",
                                                    ]
                                },
                  install_requires=['bottle', 'jsonpickle', 'joblib', 'numpy', 'pydot', 'pyyaml', 'flake8~=3.9.2',
-                                   'pycodestyle~=2.7.0', 'Click~=8.0.1', 'requests', 'urllib3~=1.26.6', 'pandas',
-                                   'pyinstaller', 'docker==5.0.3', 'gitpython', 'tqdm']
+                                   'pycodestyle~=2.7.0', 'Click~=8.0.1', 'requests', 'urllib3~=1.26.6', 
+                                   'pandas>=2.0', 'pyinstaller', 'docker==5.0.3', 'gitpython', 'tqdm']
 
                  )


### PR DESCRIPTION
Small feature where when calling `featurecloud test start --print-logs`, the test will be started, then, the current test status will be  printed every 5s and when the test is finished, the relevant part of the controller logs as well as all client logs will be printed (first controller, then clients). It's just a small feature that I like for my debugging style tbh, but it might be useful for others that prefer cli over a frontend.